### PR TITLE
TASK-249-queue-status

### DIFF
--- a/wazo_agentd_cli/commands.py
+++ b/wazo_agentd_cli/commands.py
@@ -125,6 +125,7 @@ class StatusCommand(Lister):
         'extension',
         'context',
         'state_interface',
+        'queues',
     )
 
     @property
@@ -157,6 +158,7 @@ class StatusCommand(Lister):
                 s.extension if s.logged else '',
                 s.context if s.logged else '',
                 s.state_interface if s.logged else '',
+                s.queues,
             )
             for s in statuses
         ]

--- a/wazo_agentd_cli/formatters.py
+++ b/wazo_agentd_cli/formatters.py
@@ -38,3 +38,16 @@ class LegacyAgentStatusFormatter(ListFormatter):
                 stdout.write(
                     f'    state interface: {row[indices["state_interface"]]}\n'
                 )
+            queues = row[indices['queues']]
+            if queues:
+                stdout.write('    queues:\n')
+                for queue in queues:
+                    q_id = queue.get('id', '')
+                    name = queue.get('name', '')
+                    q_logged = queue.get('logged', False)
+                    q_paused = queue.get('paused', False)
+                    stdout.write(f'        {name} (ID {q_id}, logged: {q_logged}')
+                    if q_paused:
+                        reason = queue.get('paused_reason') or ''
+                        stdout.write(f', paused: {reason}' if reason else ', paused')
+                    stdout.write(')\n')

--- a/wazo_agentd_cli/tests/test_commands.py
+++ b/wazo_agentd_cli/tests/test_commands.py
@@ -1,7 +1,10 @@
 # Copyright 2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from __future__ import annotations
+
 from argparse import Namespace
+from typing import Any
 from unittest.mock import Mock
 
 from wazo_agentd_cli.commands import (
@@ -70,6 +73,7 @@ class TestStatusCommand:
         extension: str = '',
         context: str = '',
         state_interface: str = '',
+        queues: list[dict[str, Any]] | None = None,
     ) -> Mock:
         return Mock(
             number=number,
@@ -78,10 +82,12 @@ class TestStatusCommand:
             extension=extension,
             context=context,
             state_interface=state_interface,
+            queues=queues or [],
         )
 
     def test_single_agent_returns_columns_and_row(self) -> None:
         app = Mock()
+        queues = [{'id': 1, 'name': 'support', 'logged': True, 'paused': False}]
         status = self._make_status(
             '1001',
             42,
@@ -89,6 +95,7 @@ class TestStatusCommand:
             extension='1001',
             context='default',
             state_interface='SIP/abc',
+            queues=queues,
         )
         app.client.agents.get_agent_status_by_number.return_value = status
         cmd = StatusCommand(app, None)
@@ -103,8 +110,9 @@ class TestStatusCommand:
             'extension',
             'context',
             'state_interface',
+            'queues',
         )
-        assert rows == [('1001', 42, True, '1001', 'default', 'SIP/abc')]
+        assert rows == [('1001', 42, True, '1001', 'default', 'SIP/abc', queues)]
 
     def test_not_logged_agent_has_empty_fields(self) -> None:
         app = Mock()
@@ -115,7 +123,7 @@ class TestStatusCommand:
 
         _, rows = cmd.take_action(parsed_args)
 
-        assert rows == [('1002', 43, False, '', '', '')]
+        assert rows == [('1002', 43, False, '', '', '', [])]
 
     def test_all_agents_sorted_by_number(self) -> None:
         app = Mock()

--- a/wazo_agentd_cli/tests/test_formatters.py
+++ b/wazo_agentd_cli/tests/test_formatters.py
@@ -1,17 +1,30 @@
 # Copyright 2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from __future__ import annotations
+
 from io import StringIO
+from typing import Any
 
 from wazo_agentd_cli.formatters import LegacyAgentStatusFormatter
 
-COLUMNS = ('number', 'id', 'logged', 'extension', 'context', 'state_interface')
+COLUMNS = (
+    'number',
+    'id',
+    'logged',
+    'extension',
+    'context',
+    'state_interface',
+    'queues',
+)
 
 
 class TestLegacyAgentStatusFormatter:
     def test_logged_agent(self) -> None:
         formatter = LegacyAgentStatusFormatter()
-        data = [('1001', 42, True, '1001', 'default', 'SIP/abc')]
+        data: list[tuple[Any, ...]] = [
+            ('1001', 42, True, '1001', 'default', 'SIP/abc', [])
+        ]
         stdout = StringIO()
 
         formatter.emit_list(COLUMNS, data, stdout, parsed_args=None)
@@ -26,18 +39,61 @@ class TestLegacyAgentStatusFormatter:
 
     def test_not_logged_agent(self) -> None:
         formatter = LegacyAgentStatusFormatter()
-        data = [('1002', 43, False, '', '', '')]
+        data: list[tuple[Any, ...]] = [('1002', 43, False, '', '', '', [])]
         stdout = StringIO()
 
         formatter.emit_list(COLUMNS, data, stdout, parsed_args=None)
 
         assert stdout.getvalue() == ('Agent/1002 (ID 43)\n' '    logged: False\n')
 
+    def test_agent_with_queues(self) -> None:
+        formatter = LegacyAgentStatusFormatter()
+        queues = [
+            {'id': 1, 'name': 'support', 'logged': True, 'paused': False},
+            {
+                'id': 2,
+                'name': 'sales',
+                'logged': True,
+                'paused': True,
+                'paused_reason': 'lunch',
+            },
+        ]
+        data: list[tuple[Any, ...]] = [
+            ('1001', 42, True, '1001', 'default', 'SIP/abc', queues)
+        ]
+        stdout = StringIO()
+
+        formatter.emit_list(COLUMNS, data, stdout, parsed_args=None)
+
+        assert stdout.getvalue() == (
+            'Agent/1001 (ID 42)\n'
+            '    logged: True\n'
+            '    extension: 1001\n'
+            '    context: default\n'
+            '    state interface: SIP/abc\n'
+            '    queues:\n'
+            '        support (ID 1, logged: True)\n'
+            '        sales (ID 2, logged: True, paused: lunch)\n'
+        )
+
+    def test_agent_with_paused_queue_no_reason(self) -> None:
+        formatter = LegacyAgentStatusFormatter()
+        queues = [{'id': 1, 'name': 'support', 'logged': True, 'paused': True}]
+        data: list[tuple[Any, ...]] = [
+            ('1001', 42, True, '1001', 'default', 'SIP/abc', queues)
+        ]
+        stdout = StringIO()
+
+        formatter.emit_list(COLUMNS, data, stdout, parsed_args=None)
+
+        output = stdout.getvalue()
+        assert '        support (ID 1, logged: True, paused)\n' in output
+
     def test_multiple_agents(self) -> None:
         formatter = LegacyAgentStatusFormatter()
-        data = [
-            ('1001', 42, True, '1001', 'default', 'SIP/abc'),
-            ('1002', 43, False, '', '', ''),
+        data: list[tuple[Any, ...]] = [
+            ('1001', 42, True, '1001', 'default', 'SIP/abc', []),
+            ('1002', 43, False, '', '', '', []),
         ]
         stdout = StringIO()
 


### PR DESCRIPTION
Why: the wazo-agentd API already returns queue membership data per
agent (name, id, logged, paused state) but the CLI was not displaying
it. This information is useful for debugging agent routing issues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive CLI output change with straightforward formatting logic; risk is mainly minor output/compatibility changes for consumers expecting the old column set.
> 
> **Overview**
> `agent status` now includes each agent’s queue memberships by adding a `queues` column to `StatusCommand` and rendering that data in the legacy formatter (including paused state and optional pause reason).
> 
> Tests were updated/added to cover the new `queues` field in command output and the formatter’s queue printing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f90f87a1b0ae20e34f487b2b6d606e51b7e241b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->