### PR TITLE
TASK-250-admin-queue-login-v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Agent/1004 (ID 4)
 - `login <agent_number> <extension> <context>` - Login agent
 - `logoff <agent_number|all>` - Logoff agent or all agents
 - `relog all [--timeout <seconds>]` - Relog all currently logged agents
+- `queue login <agent_id> <queue_id>` - Login agent to queue
+- `queue logoff <agent_id> <queue_id>` - Logoff agent from queue
 - `pause <agent_number>` - Pause agent
 - `unpause <agent_number>` - Unpause agent
 - `status [<agent_number>]` - Get status of one or all agents

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,8 @@ setup(
             'relog_all = wazo_agentd_cli.commands:RelogAllCommand',
             'pause = wazo_agentd_cli.commands:PauseCommand',
             'unpause = wazo_agentd_cli.commands:UnpauseCommand',
+            'queue_login = wazo_agentd_cli.commands:QueueLoginCommand',
+            'queue_logoff = wazo_agentd_cli.commands:QueueLogoffCommand',
             'status = wazo_agentd_cli.commands:StatusCommand',
         ],
     },

--- a/wazo_agentd_cli/commands.py
+++ b/wazo_agentd_cli/commands.py
@@ -115,6 +115,36 @@ class UnpauseCommand(Command):
         self.app.client.agents.unpause_agent_by_number(parsed_args.agent_number)
 
 
+class QueueLoginCommand(Command):
+    """Login agent to queue"""
+
+    def get_parser(self, *args: Any, **kwargs: Any) -> argparse.ArgumentParser:
+        parser = super().get_parser(*args, **kwargs)
+        parser.add_argument('agent_id', type=int, help='Agent ID')
+        parser.add_argument('queue_id', type=int, help='Queue ID')
+        return parser
+
+    def take_action(self, parsed_args: argparse.Namespace) -> None:
+        self.app.client.agents.user_agent_login_to_queue(
+            parsed_args.queue_id, agent_id=parsed_args.agent_id
+        )
+
+
+class QueueLogoffCommand(Command):
+    """Logoff agent from queue"""
+
+    def get_parser(self, *args: Any, **kwargs: Any) -> argparse.ArgumentParser:
+        parser = super().get_parser(*args, **kwargs)
+        parser.add_argument('agent_id', type=int, help='Agent ID')
+        parser.add_argument('queue_id', type=int, help='Queue ID')
+        return parser
+
+    def take_action(self, parsed_args: argparse.Namespace) -> None:
+        self.app.client.agents.user_agent_logoff_from_queue(
+            parsed_args.queue_id, agent_id=parsed_args.agent_id
+        )
+
+
 class StatusCommand(Lister):
     """Get status of agent"""
 

--- a/wazo_agentd_cli/commands.py
+++ b/wazo_agentd_cli/commands.py
@@ -125,8 +125,8 @@ class QueueLoginCommand(Command):
         return parser
 
     def take_action(self, parsed_args: argparse.Namespace) -> None:
-        self.app.client.agents.user_agent_login_to_queue(
-            parsed_args.queue_id, agent_id=parsed_args.agent_id
+        self.app.client.agents.agent_login_to_queue(
+            parsed_args.agent_id, parsed_args.queue_id
         )
 
 
@@ -140,8 +140,8 @@ class QueueLogoffCommand(Command):
         return parser
 
     def take_action(self, parsed_args: argparse.Namespace) -> None:
-        self.app.client.agents.user_agent_logoff_from_queue(
-            parsed_args.queue_id, agent_id=parsed_args.agent_id
+        self.app.client.agents.agent_logoff_from_queue(
+            parsed_args.agent_id, parsed_args.queue_id
         )
 
 

--- a/wazo_agentd_cli/tests/test_commands.py
+++ b/wazo_agentd_cli/tests/test_commands.py
@@ -72,9 +72,7 @@ class TestQueueLoginCommand:
         cmd = QueueLoginCommand(app, None)
         parsed_args = Namespace(agent_id=42, queue_id=1)
         cmd.take_action(parsed_args)
-        app.client.agents.user_agent_login_to_queue.assert_called_once_with(
-            1, agent_id=42
-        )
+        app.client.agents.agent_login_to_queue.assert_called_once_with(42, 1)
 
 
 class TestQueueLogoffCommand:
@@ -83,9 +81,7 @@ class TestQueueLogoffCommand:
         cmd = QueueLogoffCommand(app, None)
         parsed_args = Namespace(agent_id=42, queue_id=1)
         cmd.take_action(parsed_args)
-        app.client.agents.user_agent_logoff_from_queue.assert_called_once_with(
-            1, agent_id=42
-        )
+        app.client.agents.agent_logoff_from_queue.assert_called_once_with(42, 1)
 
 
 class TestStatusCommand:

--- a/wazo_agentd_cli/tests/test_commands.py
+++ b/wazo_agentd_cli/tests/test_commands.py
@@ -10,6 +10,8 @@ from unittest.mock import Mock
 from wazo_agentd_cli.commands import (
     LoginCommand,
     LogoffCommand,
+    QueueLoginCommand,
+    QueueLogoffCommand,
     RelogAllCommand,
     StatusCommand,
 )
@@ -61,6 +63,28 @@ class TestRelogAllCommand:
         cmd.take_action(parsed_args)
         app.client.agents.relog_all_agents.assert_called_once_with(
             recurse=True, timeout=None
+        )
+
+
+class TestQueueLoginCommand:
+    def test_take_action(self) -> None:
+        app = Mock()
+        cmd = QueueLoginCommand(app, None)
+        parsed_args = Namespace(agent_id=42, queue_id=1)
+        cmd.take_action(parsed_args)
+        app.client.agents.user_agent_login_to_queue.assert_called_once_with(
+            1, agent_id=42
+        )
+
+
+class TestQueueLogoffCommand:
+    def test_take_action(self) -> None:
+        app = Mock()
+        cmd = QueueLogoffCommand(app, None)
+        parsed_args = Namespace(agent_id=42, queue_id=1)
+        cmd.take_action(parsed_args)
+        app.client.agents.user_agent_logoff_from_queue.assert_called_once_with(
+            1, agent_id=42
         )
 
 


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/wazo-agentd-client/pull/34
- **Add queue information to status output**
- **Add queue login and queue logoff CLI commands**


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new CLI commands and extends `status` output with queue data, which may impact users/scripts that parse the existing status columns. Changes are otherwise confined to CLI wiring and client method calls.
> 
> **Overview**
> Adds queue session management to the CLI via new `queue login <agent_id> <queue_id>` and `queue logoff <agent_id> <queue_id>` commands, wired into `setup.py` entry points and documented in `README.md`.
> 
> Extends `status` results to include a new `queues` column/field, and adds unit tests covering the new commands and the updated status row shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6482d6c0e2563e4b83f719e28767594814465253. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->