### PR TITLE
[TASK-252] add --all-queues flag to relog all queues

### DIFF
--- a/wazo_agentd_cli/commands.py
+++ b/wazo_agentd_cli/commands.py
@@ -83,11 +83,19 @@ class RelogAllCommand(Command):
         parser.add_argument(
             '--timeout', type=int, default=None, help='Timeout in seconds'
         )
+        parser.add_argument(
+            '--all-queues',
+            action='store_true',
+            help='Relog each agent into all of its assigned queues, restoring '
+            'membership for queues the agent was previously logged off from',
+        )
         return parser
 
     def take_action(self, parsed_args: argparse.Namespace) -> None:
         self.app.client.agents.relog_all_agents(
-            recurse=True, timeout=parsed_args.timeout
+            recurse=True,
+            all_queues=parsed_args.all_queues,
+            timeout=parsed_args.timeout,
         )
 
 

--- a/wazo_agentd_cli/tests/test_commands.py
+++ b/wazo_agentd_cli/tests/test_commands.py
@@ -50,19 +50,28 @@ class TestRelogAllCommand:
     def test_with_timeout(self) -> None:
         app = Mock()
         cmd = RelogAllCommand(app, None)
-        parsed_args = Namespace(timeout=30)
+        parsed_args = Namespace(timeout=30, all_queues=False)
         cmd.take_action(parsed_args)
         app.client.agents.relog_all_agents.assert_called_once_with(
-            recurse=True, timeout=30
+            recurse=True, all_queues=False, timeout=30
         )
 
     def test_without_timeout(self) -> None:
         app = Mock()
         cmd = RelogAllCommand(app, None)
-        parsed_args = Namespace(timeout=None)
+        parsed_args = Namespace(timeout=None, all_queues=False)
         cmd.take_action(parsed_args)
         app.client.agents.relog_all_agents.assert_called_once_with(
-            recurse=True, timeout=None
+            recurse=True, all_queues=False, timeout=None
+        )
+
+    def test_with_all_queues(self) -> None:
+        app = Mock()
+        cmd = RelogAllCommand(app, None)
+        parsed_args = Namespace(timeout=None, all_queues=True)
+        cmd.take_action(parsed_args)
+        app.client.agents.relog_all_agents.assert_called_once_with(
+            recurse=True, all_queues=True, timeout=None
         )
 
 


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/wazo-agentd-client/pull/35


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small CLI surface-area change that only adds an optional flag and updates the client call/tests, with no complex logic or security-sensitive behavior changed.
> 
> **Overview**
> Adds an `--all-queues` flag to `RelogAllCommand` so `relog_all_agents` can optionally relog agents into *all* assigned queues (restoring memberships previously logged off).
> 
> Updates the command’s client call to pass `all_queues` through, and extends unit tests to cover default behavior and the new flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baff6d83ce002abded4b245ba666e27866c1f910. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->