### PR TITLE
ITEM-414-cliff-framework

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
             'wazo-agentd-cli = wazo_agentd_cli.main:main',
         ],
         'cliff.formatter.list': [
-            'legacy = wazo_agentd_cli.formatters:LegacyAgentStatusFormatter',
+            'agentd_legacy = wazo_agentd_cli.formatters:LegacyAgentStatusFormatter',
         ],
         'wazo_agentd_cli.commands': [
             'add = wazo_agentd_cli.commands:AddAgentToQueueCommand',

--- a/wazo_agentd_cli/commands.py
+++ b/wazo_agentd_cli/commands.py
@@ -168,7 +168,7 @@ class StatusCommand(Lister):
 
     @property
     def formatter_default(self) -> str:
-        return 'legacy'
+        return 'agentd_legacy'
 
     def get_parser(self, *args: Any, **kwargs: Any) -> argparse.ArgumentParser:
         parser = super().get_parser(*args, **kwargs)


### PR DESCRIPTION
Why: 'legacy' is too generic for a cliff formatter entry point shared
across the cliff namespace and risks colliding with other tools'
formatters. Prefix it with the service name to keep it unique.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Naming-only change with a small CLI compatibility break for scripts that used `-f legacy`.
> 
> **Overview**
> Renames the shared **cliff** list formatter entry point from `legacy` to **`agentd_legacy`** in `setup.py` so it stays unique in the global `cliff.formatter.list` namespace.
> 
> **`StatusCommand`**’s default formatter is updated to match, so `wazo-agentd-cli status` still uses the same legacy text output unless `-f` selects another format. Anyone explicitly passing `-f legacy` must switch to **`-f agentd_legacy`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcec0dc8ba57087969c9f4b9a5dd84040e13c0fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->